### PR TITLE
Support dgTMatrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ sp_mat = as_sparse(rObj)
 sce = as_SCE(rObj)
 ```
 
-For more use cases converting `data.frame`, `dgCMatrix`, `dgRMatrix` to Python, checkout the [documentation](https://biocpy.github.io/rds2py/).
+For more use cases converting `data.frame`, `dgCMatrix`, `dgRMatrix`, `dgTMatrix` to Python, checkout the [documentation](https://biocpy.github.io/rds2py/).
 
 ***If you want to add more representations, feel free to send a PR on this repository!***
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -24,7 +24,7 @@ The package provides friendly functions to convert some R representations to use
 
 ### Matrices
 
-Use these methods if the RDS file contains either a sparse matrix (`dgCMatrix` or `dgRMatrix`) or a dense matrix.
+Use these methods if the RDS file contains either a sparse matrix (`dgCMatrix`, `dgRMatrix`, or `dgTMatrix`) or a dense matrix.
 
 
 ***Note: If an R object contains `dims` in the `attributes`, we consider this as a matrix.***

--- a/src/rds2py/interface.py
+++ b/src/rds2py/interface.py
@@ -52,9 +52,9 @@ def as_sparse_matrix(robj: MutableMapping) -> sp.spmatrix:
     """
     cls = get_class(robj)
 
-    if cls not in ["dgCMatrix", "dgRMatrix"]:
+    if cls not in ["dgCMatrix", "dgRMatrix", "dgTMatrix"]:
         raise TypeError(
-            f"obj is not a supported sparse matrix format (`dgCMatrix`, `dgRMatrix`) but is `{cls}`"
+            f"obj is not a supported sparse matrix format (`dgCMatrix`, `dgRMatrix`, `dgTMatrix`) but is `{cls}`"
         )
 
     if cls == "dgCMatrix":
@@ -73,6 +73,18 @@ def as_sparse_matrix(robj: MutableMapping) -> sp.spmatrix:
                 robj["attributes"]["x"]["data"],
                 robj["attributes"]["i"]["data"],
                 robj["attributes"]["p"]["data"],
+            ),
+            shape=tuple(robj["attributes"]["Dim"]["data"].tolist()),
+        )
+
+    if cls == "dgTMatrix":
+        return sp.csr_matrix(
+            (
+                robj["attributes"]["x"]["data"],
+                (
+                    robj["attributes"]["i"]["data"],
+                    robj["attributes"]["j"]["data"],
+                ),
             ),
             shape=tuple(robj["attributes"]["Dim"]["data"].tolist()),
         )
@@ -137,7 +149,7 @@ def as_SCE(robj: MutableMapping) -> np.ndarray:
 
         asy_cls = get_class(idx_asy)
 
-        if asy_cls in ["dgCMatrix", "dgRMatrix"]:
+        if asy_cls in ["dgCMatrix", "dgRMatrix", "dgTMatrix"]:
             robj_asys[asy_names[idx]] = as_sparse_matrix(idx_asy)
             if assay_dims is None:
                 assay_dims = robj_asys[asy_names[idx]].shape


### PR DESCRIPTION
This pull request adds support for dgTMatrix - I used pg 40 of https://cran.r-project.org/web/packages/Matrix/Matrix.pdf and https://slowkow.com/notes/sparse-matrix/#the-triplet-format-in-dgtmatrix as references, and call [csr_matrix](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.csr_matrix.html) using the `(data, (row_ind, col_ind)), shape` parameter format